### PR TITLE
Add support for specific help and unit labels

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Fri Mar 16 06:42:38 GMT 2012
+#Thu Mar 22 10:18:10 CET 2012
 app.grails.version=2.0.1
 app.name=fields
 plugins.release=2.0.0.BUILD-SNAPSHOT

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -278,7 +278,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		attrs.value = model.value
 		if (model.required) attrs.required = "" // TODO: configurable how this gets output? Some people prefer required="required"
 		if (model.invalid) attrs.invalid = ""
-		if (!model.constraints.editable) attrs.readonly = ""
+		if (!model.constraints?.editable) attrs.readonly = ""
 
 		if (model.type in [String, null]) {
 			return renderStringInput(model, attrs)
@@ -322,24 +322,24 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
 	private String renderStringInput(Map model, Map attrs) {
 		if (!attrs.type) {
-			if (model.constraints.inList) {
-				attrs.from = model.constraints.inList
+			if (model.constraints?.inList) {
+				attrs.from = model.constraints?.inList
 				if (!model.required) attrs.noSelection = ["": ""]
 				return g.select(attrs)
 			}
-			else if (model.constraints.password) {
+			else if (model.constraints?.password) {
 				attrs.type = "password"
 				attrs.remove('value')
 			}
-			else if (model.constraints.email) attrs.type = "email"
-			else if (model.constraints.url) attrs.type = "url"
+			else if (model.constraints?.email) attrs.type = "email"
+			else if (model.constraints?.url) attrs.type = "url"
 			else attrs.type = "text"
 		}
 
-		if (model.constraints.matches) attrs.pattern = model.constraints.matches
-		if (model.constraints.maxSize) attrs.maxlength = model.constraints.maxSize
+		if (model.constraints?.matches) attrs.pattern = model.constraints?.matches
+		if (model.constraints?.maxSize) attrs.maxlength = model.constraints?.maxSize
 
-		if (model.constraints.widget == 'textarea') {
+		if (model.constraints?.widget == 'textarea') {
 			attrs.remove('type')
 			return g.textArea(attrs)
 		}
@@ -347,18 +347,18 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 	}
 
 	private String renderNumericInput(Map model, Map attrs) {
-		if (!attrs.type && model.constraints.inList) {
-			attrs.from = model.constraints.inList
+		if (!attrs.type && model.constraints?.inList) {
+			attrs.from = model.constraints?.inList
 			if (!model.required) attrs.noSelection = ["": ""]
 			return g.select(attrs)
-		} else if (model.constraints.range) {
+		} else if (model.constraints?.range) {
 			attrs.type = attrs.type ?: "range"
-			attrs.min = model.constraints.range.from
-			attrs.max = model.constraints.range.to
+			attrs.min = model.constraints?.range.from
+			attrs.max = model.constraints?.range.to
 		} else {
 			attrs.type = attrs.type ?: "number"
-			if (model.constraints.min != null) attrs.min = model.constraints.min
-			if (model.constraints.max != null) attrs.max = model.constraints.max
+			if (model.constraints?.min != null) attrs.min = model.constraints?.min
+			if (model.constraints?.max != null) attrs.max = model.constraints?.max
 		}
 		return g.field(attrs)
 	}

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -77,7 +77,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 			def model = buildModel(propertyAccessor, attrs)
 			def fieldAttrs = [:]
 			def inputAttrs = [:]
-			
+
 			attrs.each { k, v ->
 				if (k?.startsWith("input-"))
 					inputAttrs[k.replace("input-", '')] = v
@@ -136,7 +136,9 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 				property: propertyAccessor.pathFromRoot,
 				type: propertyAccessor.propertyType,
 				beanClass: propertyAccessor.beanClass,
-				label: resolveLabelText(propertyAccessor, attrs),
+				label: resolveLabelText(propertyAccessor, 'label', attrs),
+				helpLabel: resolveLabelText(propertyAccessor, 'helpLabel', attrs),
+				unitLabel: resolveLabelText(propertyAccessor, 'unitLabel', attrs),
 				value: (value instanceof Number || value) ? value : valueDefault,
 				constraints: propertyAccessor.constraints,
 				persistentProperty: propertyAccessor.persistentProperty,
@@ -167,7 +169,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		if (!bean) bean = beanAttribute
 		bean
 	}
-	
+
 	private String resolvePrefix(prefixAttribute) {
 		def prefix = pageScope.variables[PREFIX_PAGE_SCOPE_VARIABLE]
 		// Tomcat throws NPE if you query pageScope for null/empty values
@@ -208,21 +210,39 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		return !body.is(GroovyPage.EMPTY_BODY_CLOSURE)
 	}
 
-	private String resolveLabelText(BeanPropertyAccessor propertyAccessor, Map attrs) {
+	private String resolveLabelText(BeanPropertyAccessor propertyAccessor, String labelType, Map attrs) {
 		def labelText
-		def label = attrs.remove('label')
+		def label = attrs.remove(labelType)
 		if (label) {
 			labelText = message(code: label, default: label)
 		}
-		if (!labelText && propertyAccessor.labelKeys) {
-			labelText = resolveMessage(propertyAccessor.labelKeys, propertyAccessor.defaultLabel)
-		}
-		if (!labelText) {
-			labelText = propertyAccessor.defaultLabel
-		}
+    if (!labelText) {
+      switch (labelType) {
+        case 'label':
+          if (!labelText && propertyAccessor.labelKeys) {
+            labelText = resolveMessage(propertyAccessor.labelKeys, propertyAccessor.defaultLabel)
+          }
+          if (!labelText) {
+            labelText = propertyAccessor.defaultLabel
+          }
+          break
+
+        case 'unitLabel':
+          if (!labelText && propertyAccessor.unitLabelKeys) {
+            labelText = resolveMessage(propertyAccessor.unitLabelKeys, '')
+          }
+          break
+
+        case 'helpLabel':
+          if (!labelText && propertyAccessor.helpLabelKeys) {
+            labelText = resolveMessage(propertyAccessor.helpLabelKeys, '')
+          }
+          break
+      }
+    }
 		labelText
 	}
-	
+
 	private String resolveMessage(List<String> keysInPreferenceOrder, String defaultMessage) {
 		def message = keysInPreferenceOrder.findResult { key ->
 			message code: key, default: null
@@ -243,6 +263,12 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 				}
 			}
 			mkp.yieldUnescaped model.widget
+      if (model.unitLabel) {
+        span(class: 'unit-label', model.unitLabel)
+      }
+      if (model.helpLabel) {
+        div(class: 'help-label', model.helpLabel)
+      }
 		}
 		writer.toString()
 	}
@@ -312,7 +338,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
 		if (model.constraints.matches) attrs.pattern = model.constraints.matches
 		if (model.constraints.maxSize) attrs.maxlength = model.constraints.maxSize
-		
+
 		if (model.constraints.widget == 'textarea') {
 			attrs.remove('type')
 			return g.textArea(attrs)

--- a/src/docs/guide/customizingFieldRendering.gdoc
+++ b/src/docs/guide/customizingFieldRendering.gdoc
@@ -68,6 +68,8 @@ The _f:field_ and _f:input_ tags will pass the following parameters to your temp
 *property* | String | The _property_ attribute as passed to the _f:field_ or _f:input_ tag. This would generally be useful for the _name_ attribute of a form input.
 *type* | Class | The property type.
 *label* | String | The field label text. This is based on the _label_ attribute passed to the _f:field_ or _f:input_ tag. If no _label_ attribute was used the label is resolved by convention - see below.
+*helpLabel* | String | The field's help label text. This is based on the _helpLabel_ attribute passed to the _f:field_ tag. If no _helpLabel_ attribute was used the help label is resolved by convention - see below.
+*unitLabel* | String | The field's unit label text. This is based on the _unitLabel_ attribute passed to the _f:field_ tag. If no _unitLabel_ attribute was used the unit label is resolved by convention - see below.
 *value* | Object | the property value. This can also be overridden or defaulted if the _value_ or _default_ attribute was passed to _f:field_ or _f:input_.
 *constraints* | ConstrainedProperty | The constraints for the property if the bean is a domain or command object.
 *persistentProperty* | GrailsDomainClassProperty | The persistent property object if the bean is a domain object.
@@ -90,8 +92,10 @@ If the _bean_ attribute was not supplied to _f:field_ then _bean_, _type_, _valu
 
 h3. Field labels
 
-If the _label_ attribute is not supplied to the _f:field_ tag then the label string passed to the field template is resolved by convention. The plugin uses the following order of preference for the label:
+If the _label_, _unitLabel_, or _helpLabel_ attribute is not supplied to the _f:field_ tag then the label string passed to the field template is resolved by convention. The plugin uses the following order of preference for the label:
 
-# An i18n message using the key '_beanClass_._path_@.label@'. For example when using @<f:field bean="personInstance" property="address.city"/>@ the plugin will try the i18n key @person.address.city.label@. If the property path contains any index it is removed so @<f:field bean="authorInstance" property="books[0].title"/>@ would use the key @author.books.title.label@.
+# An i18n message using the key '_beanClass_._path_@.label@' ('_beanClass_._path_@.help.label@' and '_beanClass_._path_@.unit.label@' respectively). For example when using @<f:field bean="personInstance" property="address.city"/>@ the plugin will try the i18n key @person.address.city.label@ (and @person.address.city.help.label@ / @person.address.city.unit.label@ respectively). If the property path contains any index it is removed so @<f:field bean="authorInstance" property="books[0].title"/>@ would use the key @author.books.title.label@.
 # An i18n message using the key '_objectType_._propertyName_@.label@'. For example when using @<f:field bean="personInstance" property="address.city"/>@ the plugin will try the i18n key @address.city.label@.
 # The natural property name. For example when using @<f:field bean="personInstance" property="dateOfBirth"/>@ the plugin will use the label @"Date Of Birth"@.
+
+# The default for help and unit labels is an empty string. Help and unit labels are not rendered if they are not defined.

--- a/src/docs/ref/Tags/field.gdoc
+++ b/src/docs/ref/Tags/field.gdoc
@@ -42,6 +42,8 @@ h2. Attributes
 *required* | | Overrides the required status of the property. By default this is worked out based on the property's constraints.
 *invalid* | | Overrides the validity of the property. By default this is worked out using the bean's _errors_ property for domain and command objects.
 *label* | | Overrides the field label passed to the template. This value may either be an i18n key or a literal string.
+*helpLabel* | | Overrides the field's help label passed to the template. This value may either be an i18n key or a literal string.
+*unitLabel* | | Overrides the field's unit label passed to the template. This value may either be an i18n key or a literal string.
 *prefix* | String | A string (including the trailing period) that should be appended before the input name such as @name="${prefix}propertyName"@.  The label is also modified.
 {table}
 

--- a/src/groovy/grails/plugin/formfields/BeanPropertyAccessor.groovy
+++ b/src/groovy/grails/plugin/formfields/BeanPropertyAccessor.groovy
@@ -87,6 +87,16 @@ interface BeanPropertyAccessor {
 	 */
 	List<String> getLabelKeys()
 
+  /**
+   * @return the i18n keys used to resolve a help label for the property at the end of the path in order of preference.
+   */
+  List<String> getHelpLabelKeys()
+
+  /**
+   * @return the i18n keys used to resolve a help label for the property at the end of the path in order of preference.
+   */
+  List<String> getUnitLabelKeys()
+
 	/**
 	 * @return default label text for the property at the end of the path.
 	 */

--- a/src/groovy/grails/plugin/formfields/BeanPropertyAccessorImpl.groovy
+++ b/src/groovy/grails/plugin/formfields/BeanPropertyAccessorImpl.groovy
@@ -53,6 +53,20 @@ class BeanPropertyAccessorImpl implements BeanPropertyAccessor {
 		].unique()
 	}
 
+  List<String> getHelpLabelKeys() {
+    [
+      "${GrailsNameUtils.getPropertyName(rootBeanType.simpleName)}.${pathFromRoot}.help.label".replaceAll(/\[(.+)\]/, ''),
+      "${GrailsNameUtils.getPropertyName(beanType.simpleName)}.${propertyName}.help.label"
+    ].unique()
+  }
+
+  List<String> getUnitLabelKeys() {
+    [
+      "${GrailsNameUtils.getPropertyName(rootBeanType.simpleName)}.${pathFromRoot}.unit.label".replaceAll(/\[(.+)\]/, ''),
+      "${GrailsNameUtils.getPropertyName(beanType.simpleName)}.${propertyName}.unit.label"
+    ].unique()
+  }
+
 	String getDefaultLabel() {
 		GrailsNameUtils.getNaturalName(propertyName)
 	}

--- a/src/groovy/grails/plugin/formfields/PropertyPathAccessor.groovy
+++ b/src/groovy/grails/plugin/formfields/PropertyPathAccessor.groovy
@@ -32,7 +32,9 @@ class PropertyPathAccessor implements BeanPropertyAccessor {
 	ConstrainedProperty getConstraints() { new ConstrainedProperty(Object, propertyName, String) }
 	GrailsDomainClassProperty getPersistentProperty() { null }
 	List<String> getLabelKeys() { EMPTY_LIST }
-	List<FieldError> getErrors() { EMPTY_LIST }
+  List<String> getHelpLabelKeys() { EMPTY_LIST }
+  List<String> getUnitLabelKeys() { EMPTY_LIST }
+  List<FieldError> getErrors() { EMPTY_LIST }
 	boolean isRequired() { false }
 	boolean isInvalid() { false }
 }

--- a/test/unit/grails/plugin/formfields/DefaultFieldTemplateSpec.groovy
+++ b/test/unit/grails/plugin/formfields/DefaultFieldTemplateSpec.groovy
@@ -13,6 +13,8 @@ class DefaultFieldTemplateSpec extends Specification {
 	void setup() {
 		model.invalid = false
 		model.label = 'label'
+		model.unitLabel = 'unit label'
+		model.helpLabel = 'help label'
 		model.property = 'property'
 		model.required = false
 		model.widget = '<input name="property">'
@@ -34,9 +36,17 @@ class DefaultFieldTemplateSpec extends Specification {
 		def label = root.find('label')
 		label.text() == 'label'
 		label.attr('for') == 'property'
-		
+
 		and:
 		label.next().is('input[name=property]')
+
+    and:
+    def unitLabel = root.find('span[class=unit-label]')
+    unitLabel.text() == 'unit label'
+
+    and:
+    def helpLabel = root.find('div[class=help-label]')
+    helpLabel.text() == 'help label'
 	}
 
 	void "container marked as invalid"() {


### PR DESCRIPTION
Hi!

First of all: great plugin!! Thanks a lot! Two little things I was missing are default unit and help labels for form fields. That's why I added that functionality.

More specific, the attached changes add support for a "helpLabel" and "unitLabel" template parameter. These are resolved the same way as the already existing "label" variable. 

By default both labels are completely omitted from the default rendering if they are undefined. But if defined, the unitLabel is rendered as span after the input widget while the helpLabel is rendered as div below the input widget. 

Thanks for considering this patch for addition.

Cheers,
Carsten