### PR TITLE
Fix for DisplayTagSpec.'renders date values using g:formatDate'

### DIFF
--- a/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -34,8 +34,11 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 	}
 
 	void 'renders date values using g:formatDate'() {
+		given:
+		messageSource.addMessage('default.date.format', request.locale, 'yyyy-MM-dd HH:mm:ss')
+
 		expect:
-		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 [A-Z]{3}/
+		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00/
 	}
 
 	void 'displays using template if one is present'() {

--- a/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -41,6 +41,11 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00/
 	}
 
+    void 'renders date values using g:formatDate without default dateformat'() {
+   		expect:
+   		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 [A-Z]{3,4}/
+   	}
+
 	void 'displays using template if one is present'() {
 		given:
 		views["/_fields/default/_display.gsp"] = '<dt>${label}</dt><dd>${value}</dd>'

--- a/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -20,6 +20,17 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 	}
 
+    private void prepareBirthOfDate(String timeZone) {
+        def forcedTimeZone = TimeZone.getTimeZone(timeZone)
+        TimeZone.setDefault(forcedTimeZone)
+
+        def c = Calendar.instance
+        c.setTimeZone(forcedTimeZone)
+        c.set(1987, 3, 19, 0, 0, 0)
+
+        personInstance.dateOfBirth = c.time
+    }
+
 	void 'renders value using g:fieldValue if no template is present'() {
 		expect:
 		applyTemplate('<f:display bean="personInstance" property="name"/>', [personInstance: personInstance]) == personInstance.name
@@ -33,6 +44,7 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 		applyTemplate('<f:display bean="personInstance" property="minor"/>', [personInstance: personInstance]) == 'Yes'
 	}
 
+    @Issue('https://github.com/robfletcher/grails-fields/issues/99')
 	void 'renders date values using g:formatDate'() {
 		given:
 		messageSource.addMessage('default.date.format', request.locale, 'yyyy-MM-dd HH:mm:ss')
@@ -41,9 +53,56 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00/
 	}
 
+	void 'renders date values using g:formatDate with dateformat and timezone UTC'() {
+		given:
+		messageSource.addMessage('default.date.format', request.locale, 'yyyy-MM-dd HH:mm:ss z')
+        prepareBirthOfDate("UTC")
+
+   		expect:
+   		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 UTC/
+
+        and:
+        TimeZone.setDefault(null)
+	}
+
+	void 'renders date values using g:formatDate with dateformat and timezone GMT'() {
+		given:
+		messageSource.addMessage('default.date.format', request.locale, 'yyyy-MM-dd HH:mm:ss z')
+        prepareBirthOfDate("GMT")
+
+   		expect:
+   		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 GMT/
+
+        and:
+        TimeZone.setDefault(null)
+	}
+
+    @Issue('https://github.com/robfletcher/grails-fields/issues/99')
     void 'renders date values using g:formatDate without default dateformat'() {
    		expect:
    		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 [A-Z]{3,4}/
+   	}
+
+    void 'renders date values using g:formatDate without default dateformat and timezone UTC'() {
+        given:
+        prepareBirthOfDate("UTC")
+
+   		expect:
+   		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 UTC/
+
+        and:
+        TimeZone.setDefault(null)
+   	}
+
+    void 'renders date values using g:formatDate without default dateformat and timezone GMT'() {
+        given:
+        prepareBirthOfDate("GMT")
+
+   		expect:
+   		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 GMT/
+
+        and:
+        TimeZone.setDefault(null)
    	}
 
 	void 'displays using template if one is present'() {


### PR DESCRIPTION
Hi,
I had a problem running the tests (DisplyTagSpec) while using TimeZone "CEST".
Adding a "messageSource" with "default.date.format" without timezone pattern fixes this test failure.
The previous test always expected 3 letters which does not pass "CEST" for example.

Best regards,
hacki
