### PR TITLE
Adding 'components' templates

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -31,24 +31,20 @@ grails.project.dependency.resolution = {
 		inherits true
 		grailsHome()
         grailsCentral()
-		grailsRepo "http://grails.org/plugins"
+//		grailsRepo "http://grails.org/plugins"
 		grailsPlugins()
         mavenCentral()
         mavenLocal()
     }
 
     dependencies {
-		test 'javassist:javassist:3.12.0.GA'
-		test('org.jodd:jodd-wot:3.3.4') {
-			excludes 'slf4j-api', 'asm'
-		}
+        test "org.spockframework:spock-grails-support:0.7-groovy-2.0"
     }
 
     plugins {
-		test(':spock:0.6') {
-			export = false
-			excludes 'groovy-all'
-		}
+        test(":spock:0.7") {
+            exclude "spock-grails-support"
+        }
         build(':release:2.0.3', ':rest-client-builder:1.0.2') {
             export = false
         }

--- a/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
+++ b/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
@@ -30,14 +30,14 @@ class FormFieldsTemplateService {
     GrailsConventionGroovyPageLocator groovyPageLocator
     GrailsPluginManager pluginManager
 
-    Map findTemplate(BeanPropertyAccessor propertyAccessor, String templateName) {
-        findTemplateCached(propertyAccessor, controllerName, actionName, templateName)
+    Map findTemplate(BeanPropertyAccessor propertyAccessor, String templateName, String componentName = "") {
+        findTemplateCached(propertyAccessor, controllerName, actionName, templateName, componentName)
     }
 
     private final Closure findTemplateCached = shouldCache() ? this.&findTemplateCacheable.memoize() : this.&findTemplateCacheable
 
-    private Map findTemplateCacheable(BeanPropertyAccessor propertyAccessor, String controllerName, String actionName, String templateName) {
-        def candidatePaths = candidateTemplatePaths(propertyAccessor, controllerName, actionName, templateName)
+    private Map findTemplateCacheable(BeanPropertyAccessor propertyAccessor, String controllerName, String actionName, String templateName, String componentName) {
+        def candidatePaths = candidateTemplatePaths(propertyAccessor, controllerName, actionName, templateName, componentName)
 
         candidatePaths.findResult { path ->
             log.debug "looking for template with path $path"
@@ -60,8 +60,13 @@ class FormFieldsTemplateService {
         GrailsNameUtils.getLogicalPropertyName(type.name, '')
     }
 
-    private List<String> candidateTemplatePaths(BeanPropertyAccessor propertyAccessor, String controllerName, String actionName, String templateName) {
+    private List<String> candidateTemplatePaths(BeanPropertyAccessor propertyAccessor, String controllerName, String actionName, String templateName, String componentName) {
         def templateResolveOrder = []
+
+        //if there is a component name then takes priority
+        if(componentName != ""){
+            templateResolveOrder << appendPiecesForUri("/_fields/_components", componentName, templateName)
+        }
 
         // if there is a controller for the current request any template in its views directory takes priority
         if (controllerName) {
@@ -126,3 +131,4 @@ class FormFieldsTemplateService {
     }
 
 }
+

--- a/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
+++ b/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
@@ -31,7 +31,7 @@ class FormFieldsTemplateService {
     GrailsPluginManager pluginManager
 
     Map findTemplate(BeanPropertyAccessor propertyAccessor, String templateName, String componentName = "") {
-        findTemplateCached(propertyAccessor, controllerName, actionName, templateName, componentName)
+        findTemplateCached.call(propertyAccessor, controllerName, actionName, templateName, componentName)
     }
 
     private final Closure findTemplateCached = shouldCache() ? this.&findTemplateCacheable.memoize() : this.&findTemplateCacheable
@@ -41,7 +41,7 @@ class FormFieldsTemplateService {
         def candidatePaths = candidateTemplatePaths(propertyAccessor, controllerName, actionName, templateName, componentName)
 
         candidatePaths.findResult { path ->
-            return findTemplateByPathCached(path)
+            return findTemplateByPathCached.call(path)
         }
     }
 

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -123,10 +123,13 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 			if (hasBody(body)) {
 				model.widget = body(model + inputAttrs)
 			} else {
-				model.widget = renderWidget(propertyAccessor, model, component, inputAttrs)
+				model.widget = renderWidget(propertyAccessor, model + fieldAttrs, component, inputAttrs)
 			}
 
-            def layout = attrs.layout ?: pageScope.variables['layout']
+            def layout = attrs.layout
+            if(!layout)
+                layout = pageScope.variables['layout'] ?: 'default'
+
             out << renderLayout(layout, 'field', model + fieldAttrs)
 		}
 	}
@@ -175,7 +178,9 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		} else {
 			model.widget = renderForDisplay(propertyAccessor, model, component, attrs)
 		}
-        def layout = attrs.layout ?: pageScope.variables['layout']
+        def layout = attrs.layout
+        if(!layout)
+            layout = pageScope.variables['layout'] ?: 'default'
         out << renderLayout(layout, 'display', model + attrs)
 	}
 

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -18,10 +18,13 @@ package grails.plugin.formfields
 
 import groovy.xml.MarkupBuilder
 import org.apache.commons.lang.StringUtils
+import org.codehaus.groovy.grails.plugins.GrailsPluginManager
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
 import org.codehaus.groovy.grails.scaffolding.DomainClassPropertyComparator
 import org.codehaus.groovy.grails.web.pages.GroovyPage
 import org.codehaus.groovy.grails.commons.*
+import org.codehaus.groovy.grails.web.pages.discovery.GrailsConventionGroovyPageLocator
+import org.codehaus.groovy.grails.web.pages.discovery.GroovyPageLocator
 
 import static FormFieldsTemplateService.toPropertyNameFormat
 import static org.codehaus.groovy.grails.commons.GrailsClassUtils.getStaticPropertyValue
@@ -35,6 +38,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 	FormFieldsTemplateService formFieldsTemplateService
 	GrailsApplication grailsApplication
 	BeanPropertyAccessorFactory beanPropertyAccessorFactory
+    GrailsConventionGroovyPageLocator groovyPageLocator
+    GrailsPluginManager pluginManager
 
 	/**
 	 * @attr bean REQUIRED Name of the source bean in the GSP model.
@@ -45,6 +50,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		def bean = resolveBean(attrs.bean)
 		def prefix = resolvePrefix(attrs.prefix)
 		try {
+			pageScope.variables['layout'] = attrs.layout ?: 'default'
 			pageScope.variables[BEAN_PAGE_SCOPE_VARIABLE] = bean
 			pageScope.variables[PREFIX_PAGE_SCOPE_VARIABLE] = prefix
 			out << body()
@@ -64,6 +70,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		if (!attrs.bean) throwTagError("Tag [all] is missing required attribute [bean]")
 		def bean = resolveBean(attrs.bean)
 		def prefix = resolvePrefix(attrs.prefix)
+        pageScope.variables['layout'] = attrs.layout ?: 'default'
 		def domainClass = resolveDomainClass(bean)
 		if (domainClass) {
 			for (property in resolvePersistentProperties(domainClass, attrs)) {
@@ -116,17 +123,23 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 			if (hasBody(body)) {
 				model.widget = body(model + inputAttrs)
 			} else {
-				model.widget = renderWidget(propertyAccessor, model, inputAttrs)
+				model.widget = renderWidget(propertyAccessor, model, component, inputAttrs)
 			}
 
-            def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'field', component)
-			if (template) {
-				out << render(template: template.path, plugin: template.plugin, model: model + fieldAttrs)
-			} else {
-				out << renderDefaultField(model)
-			}
+            def layout = attrs.layout ?: pageScope.variables['layout']
+            out << renderLayout(layout, 'field', model + fieldAttrs)
 		}
 	}
+
+    private void renderLayout(layout, templateName, model){
+        def layoutTemplatePath = "/_fields/_layouts/$layout/$templateName"
+        def layoutTemplate = formFieldsTemplateService.findTemplateByPathCached(layoutTemplatePath)
+        if (layoutTemplate) {
+            out << render(template: layoutTemplate.path, plugin: layoutTemplate.plugin, model: model)
+        } else {
+            out << render(template: "/_fields/_layouts/noLayout", contextPath: pluginContextPath, model: model)
+        }
+    }
 
 	/**
 	 * @attr bean REQUIRED Name of the source bean in the GSP model.
@@ -155,14 +168,15 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
 		def propertyAccessor = resolveProperty(bean, property)
 		def model = buildModel(propertyAccessor, attrs)
+        def component = attrs.component?:''
 
 		if (hasBody(body)) {
-			model.value = body(model)
+			model.widget = body(model)
 		} else {
-			model.value = renderDefaultDisplay(model, attrs)
+			model.widget = renderForDisplay(propertyAccessor, model, component, attrs)
 		}
-        def component = attrs.component?:''
-		out << renderForDisplay(propertyAccessor, component, model, attrs)
+        def layout = attrs.layout ?: pageScope.variables['layout']
+        out << renderLayout(layout, 'display', model + attrs)
 	}
 
 	private void renderEmbeddedProperties(bean, BeanPropertyAccessor propertyAccessor, attrs) {
@@ -198,8 +212,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		]
 	}
 
-	private String renderWidget(BeanPropertyAccessor propertyAccessor, Map model, Map attrs = [:]) {
-		def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'input')
+	private String renderWidget(BeanPropertyAccessor propertyAccessor, Map model, String componentName, Map attrs = [:]) {
+		def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'field', componentName)
 		if (template) {
 			render template: template.path, plugin: template.plugin, model: model + attrs
 		} else {
@@ -207,12 +221,12 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		}
 	}
 
-	private String renderForDisplay(BeanPropertyAccessor propertyAccessor, String componentName, Map model, Map attrs = [:]) {
+	private String renderForDisplay(BeanPropertyAccessor propertyAccessor, Map model, String componentName, Map attrs = [:]) {
 		def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'display', componentName)
 		if (template) {
 			render template: template.path, plugin: template.plugin, model: model + attrs
 		} else {
-			model.value
+            renderDefaultDisplay(model, attrs)
 		}
 	}
 

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -88,6 +88,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 	 * is determined by whether there are any errors associated with it.
 	 * @attr label Overrides the default label displayed next to the input field.
 	 * @attr prefix Prefix to add to input element names.
+	 * @attr component Use a component instead of a regular field.
 	 */
 	def field = { attrs, body ->
 		if (attrs.containsKey('bean') && !attrs.bean) throwTagError("Tag [field] requires a non-null value for attribute [bean]")
@@ -95,6 +96,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
 		def bean = resolveBean(attrs.remove('bean'))
 		def property = attrs.remove('property')
+        def component = attrs.component ?: ""
 
 		def propertyAccessor = resolveProperty(bean, property)
 		if (propertyAccessor.persistentProperty?.embedded) {
@@ -117,7 +119,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 				model.widget = renderWidget(propertyAccessor, model, inputAttrs)
 			}
 
-			def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'field')
+            def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'field', component)
 			if (template) {
 				out << render(template: template.path, plugin: template.plugin, model: model + fieldAttrs)
 			} else {
@@ -159,8 +161,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		} else {
 			model.value = renderDefaultDisplay(model, attrs)
 		}
-
-		out << renderForDisplay(propertyAccessor, model, attrs)
+        def component = attrs.component?:''
+		out << renderForDisplay(propertyAccessor, component, model, attrs)
 	}
 
 	private void renderEmbeddedProperties(bean, BeanPropertyAccessor propertyAccessor, attrs) {
@@ -205,8 +207,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		}
 	}
 
-	private String renderForDisplay(BeanPropertyAccessor propertyAccessor, Map model, Map attrs = [:]) {
-		def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'display')
+	private String renderForDisplay(BeanPropertyAccessor propertyAccessor, String componentName, Map model, Map attrs = [:]) {
+		def template = formFieldsTemplateService.findTemplate(propertyAccessor, 'display', componentName)
 		if (template) {
 			render template: template.path, plugin: template.plugin, model: model + attrs
 		} else {
@@ -405,7 +407,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 			attrs.from = model.type.values()
 		}
 		return g.select(attrs)
-	}
+	  }
 
 	private String renderAssociationInput(Map model, Map attrs) {
 		attrs.id = (model.prefix ?: '') + model.property

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -24,7 +24,6 @@ import org.codehaus.groovy.grails.scaffolding.DomainClassPropertyComparator
 import org.codehaus.groovy.grails.web.pages.GroovyPage
 import org.codehaus.groovy.grails.commons.*
 import org.codehaus.groovy.grails.web.pages.discovery.GrailsConventionGroovyPageLocator
-import org.codehaus.groovy.grails.web.pages.discovery.GroovyPageLocator
 
 import static FormFieldsTemplateService.toPropertyNameFormat
 import static org.codehaus.groovy.grails.commons.GrailsClassUtils.getStaticPropertyValue
@@ -38,7 +37,6 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 	FormFieldsTemplateService formFieldsTemplateService
 	GrailsApplication grailsApplication
 	BeanPropertyAccessorFactory beanPropertyAccessorFactory
-    GrailsConventionGroovyPageLocator groovyPageLocator
     GrailsPluginManager pluginManager
 
 	/**
@@ -136,7 +134,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
     private void renderLayout(layout, templateName, model){
         def layoutTemplatePath = "/_fields/_layouts/$layout/$templateName"
-        def layoutTemplate = formFieldsTemplateService.findTemplateByPathCached(layoutTemplatePath)
+        def layoutTemplate = formFieldsTemplateService.findTemplateByPathCached.call(layoutTemplatePath)
         if (layoutTemplate) {
             out << render(template: layoutTemplate.path, plugin: layoutTemplate.plugin, model: model)
         } else {

--- a/grails-app/views/_fields/_layouts/_noLayout.gsp
+++ b/grails-app/views/_fields/_layouts/_noLayout.gsp
@@ -1,0 +1,2 @@
+<%@ page defaultCodec="html" %>
+<%= raw(widget) %>

--- a/grails-app/views/_fields/_layouts/default/_field.gsp
+++ b/grails-app/views/_fields/_layouts/default/_field.gsp
@@ -1,6 +1,6 @@
 <%@ page defaultCodec="html" %>
 <div class="form-group ${invalid ? 'error' : ''}">
-	<label class="col-sm-2 control-label" for="${property}">${label} - from grails-fields-plugin</label>
+	<label class="col-sm-2 control-label" for="${property}">${label}</label>
 	<div class="col-sm-10">
 		<%= raw(widget) %>
         <g:if test="${required}">

--- a/grails-app/views/_fields/_layouts/default/_field.gsp
+++ b/grails-app/views/_fields/_layouts/default/_field.gsp
@@ -1,0 +1,10 @@
+<%@ page defaultCodec="html" %>
+<div class="form-group ${invalid ? 'error' : ''}">
+	<label class="col-sm-2 control-label" for="${property}">${label} - from grails-fields-plugin</label>
+	<div class="col-sm-10">
+		<%= raw(widget) %>
+        <g:if test="${required}">
+            <span class="required-indicator">*</span>
+        </g:if>
+	</div>
+</div>

--- a/test/unit/grails/plugin/formfields/TransientPropertySpec.groovy
+++ b/test/unit/grails/plugin/formfields/TransientPropertySpec.groovy
@@ -21,7 +21,7 @@ class TransientPropertySpec extends AbstractFormFieldsTagLibSpec {
     def setup() {
         def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-        mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+        mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
         taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 
         userInstance = new User(email: 'rob@freeside.co', password: 'yuonocanhaz', confirmPassword: 'yuonocanhaz').save(failOnError: true)

--- a/test/unit/grails/plugin/formfields/taglib/AllTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/AllTagSpec.groovy
@@ -19,7 +19,7 @@ class AllTagSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 
 		mockEmbeddedSitemeshLayout(taglib)

--- a/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -43,7 +43,7 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 		views["/_fields/default/_display.gsp"] = '<dt>${label}</dt><dd>${value}</dd>'
 
 		and:
-		mockFormFieldsTemplateService.findTemplate(_, 'display') >> [path: '/_fields/default/display']
+		mockFormFieldsTemplateService.findTemplate(_, 'display', "") >> [path: '/_fields/default/display']
 
 		expect:
 		applyTemplate('<f:display bean="personInstance" property="name"/>', [personInstance: personInstance]) == '<dt>Name</dt><dd>Bart Simpson</dd>'
@@ -55,7 +55,7 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 		views["/_fields/default/_display.gsp"] = '<dt>${label}</dt><dd>${value}</dd>'
 
 		and:
-		mockFormFieldsTemplateService.findTemplate(_, 'display') >> [path: '/_fields/default/display']
+		mockFormFieldsTemplateService.findTemplate(_, 'display', "") >> [path: '/_fields/default/display']
 
 		expect:
 		applyTemplate('<f:display bean="personInstance" property="name">${value.reverse()}</f:display>', [personInstance: personInstance]) == '<dt>Name</dt><dd>nospmiS traB</dd>'

--- a/test/unit/grails/plugin/formfields/taglib/EmbeddedPropertiesSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/EmbeddedPropertiesSpec.groovy
@@ -19,7 +19,7 @@ class EmbeddedPropertiesSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 
         mockEmbeddedSitemeshLayout taglib

--- a/test/unit/grails/plugin/formfields/taglib/ExtraAttributesSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/ExtraAttributesSpec.groovy
@@ -19,7 +19,7 @@ class ExtraAttributesSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 	}
 

--- a/test/unit/grails/plugin/formfields/taglib/FieldNamePrefixSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/FieldNamePrefixSpec.groovy
@@ -19,7 +19,7 @@ class FieldNamePrefixSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 
 		mockEmbeddedSitemeshLayout(taglib)

--- a/test/unit/grails/plugin/formfields/taglib/FieldTagWithBodySpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/FieldTagWithBodySpec.groovy
@@ -19,7 +19,7 @@ class FieldTagWithBodySpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 	}
 

--- a/test/unit/grails/plugin/formfields/taglib/FieldTagWithoutBeanSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/FieldTagWithoutBeanSpec.groovy
@@ -17,7 +17,7 @@ class FieldTagWithoutBeanSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 	}
 

--- a/test/unit/grails/plugin/formfields/taglib/RequiredAttributesSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/RequiredAttributesSpec.groovy
@@ -18,7 +18,7 @@ class RequiredAttributesSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 	}
 

--- a/test/unit/grails/plugin/formfields/taglib/TemplateModelSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/TemplateModelSpec.groovy
@@ -19,7 +19,7 @@ class TemplateModelSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 	}
 

--- a/test/unit/grails/plugin/formfields/taglib/WithTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/WithTagSpec.groovy
@@ -19,7 +19,7 @@ class WithTagSpec extends AbstractFormFieldsTagLibSpec {
 	def setup() {
 		def taglib = applicationContext.getBean(FormFieldsTagLib)
 
-		mockFormFieldsTemplateService.findTemplate(_, 'field') >> [path: '/_fields/default/field']
+		mockFormFieldsTemplateService.findTemplate(_, 'field', "") >> [path: '/_fields/default/field']
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
 
         mockEmbeddedSitemeshLayout taglib


### PR DESCRIPTION
Added new attribute: 'component' (in 'field' or 'display' taglibs).
Now it is possible to specify which component is going to be used (it has to be placed inside _fields/_components/componentName/_field.gsp or _fields/_components/componentName/_display.gsp)

e.g.: <field bean="someBean" property="someProperty" component="time"/> (Is going to use _fields/_components/time/_field.gsp)

This is usefull to render same template multiple times across different properties.