### PR TITLE
Update BeanPropertyAccessorFactory.groovy

### DIFF
--- a/src/groovy/grails/plugin/formfields/BeanPropertyAccessorFactory.groovy
+++ b/src/groovy/grails/plugin/formfields/BeanPropertyAccessorFactory.groovy
@@ -113,6 +113,8 @@ class BeanPropertyAccessorFactory implements GrailsApplicationAware {
 	private Class resolveDomainPropertyType(GrailsDomainClass beanClass, String propertyName) {
 		def propertyNameWithoutIndex = stripIndex(propertyName)
 		def persistentProperty = beanClass.getPersistentProperty(propertyNameWithoutIndex)
+		//TODO: Verify this, a @Transient field should be usable with f:fiels in views
+		//Maybe the if statement is not needed at all...
 		if (!persistentProperty) throw new NotReadablePropertyException(beanClass.clazz, propertyNameWithoutIndex)
 		boolean isIndexed = propertyName =~ INDEXED_PROPERTY_PATTERN
 		boolean isCollection = persistentProperty.isBasicCollectionType() || persistentProperty.isAssociation()


### PR DESCRIPTION
I'm using field plugin with external model via JPA and hibernate mapping.
Works well, however I can't use <f:fields when I have fields marked with @Transient that I need in the gui but not persistent, because line 118 is throwing an exception.
However when I use groovy class with static mapWith = "none" (disable persisting into database) on other parts of my project f:fields works fine.
Maybe the check for persistentProperty in line 118 is not needed at all?