### PR TITLE
let's init findTemplateCached closure lazily

### DIFF
--- a/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
+++ b/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
@@ -36,12 +36,14 @@ class FormFieldsTemplateService {
     GrailsConventionGroovyPageLocator groovyPageLocator
     GrailsPluginManager pluginManager
 
+    private
+    Closure findTemplateCached 
+    
     Map findTemplate(BeanPropertyAccessor propertyAccessor, String templateName) {
+        if (!findTemplateCached)
+            findTemplateCached = shouldCache() ? this.&findTemplateCacheable.memoize() : this.&findTemplateCacheable
         findTemplateCached(propertyAccessor, controllerNamespace, controllerName, actionName, templateName)
     }
-
-    private
-    final Closure findTemplateCached = shouldCache() ? this.&findTemplateCacheable.memoize() : this.&findTemplateCacheable
 
     private Map findTemplateCacheable(BeanPropertyAccessor propertyAccessor, String controllerNamespace, String controllerName, String actionName, String templateName) {
         def candidatePaths = candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName)


### PR DESCRIPTION
shouldCache() tests grailsApplication.config in findTemplateCached initializer which is called at the construction stage with not-yet-injected grailsApplication. let's init findTemplateCached closure lasily with slightly worse performance, but with effective setup of Config.groovy's

grails.plugin.fields.disableLookupCache = false