### PR TITLE
Resolve templates for domain properties that have a widget constraint

### DIFF
--- a/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
+++ b/grails-app/services/grails/plugin/formfields/FormFieldsTemplateService.groovy
@@ -145,6 +145,12 @@ class FormFieldsTemplateService {
             templateResolveOrder << appendPiecesForUri('/_fields', associationPath, templateName)
         }
 
+        // if we have a domain constraint widget look in `grails-app/views/_fields/<widget>/_field.gsp`
+        def widget = getWidget(propertyAccessor.constraints)
+        if (widget) {
+            templateResolveOrder << appendPiecesForUri("/_fields", widget, templateName)
+        }
+
         // if we have a property type look in `grails-app/views/_fields/<propertyType>/_field.gsp` and equivalent for superclasses
         if (propertyAccessor.propertyType) {
             templateResolveOrder << appendPiecesForUri("/_fields", toPropertyNameFormat(propertyAccessor.propertyType), templateName)

--- a/test/unit/grails/plugin/formfields/FormFieldsTemplateServiceSpec.groovy
+++ b/test/unit/grails/plugin/formfields/FormFieldsTemplateServiceSpec.groovy
@@ -132,6 +132,70 @@ class FormFieldsTemplateServiceSpec extends Specification {
 		render(template: template.path) == 'OUTPUT FOR DISPLAY'
 	}
 
+	void "resolves wrapper template for textarea widget constraint"() {
+		given:
+		views["/_fields/default/_wrapper.gsp"] = 'DEFAULT FIELD TEMPLATE'
+		views["/_fields/string/_wrapper.gsp"] = 'PROPERTY TYPE TEMPLATE'
+		views["/_fields/textarea/_wrapper.gsp"] = 'WIDGET TEMPLATE'
+
+		and:
+		def property = factory.accessorFor(personInstance, 'biography')
+
+		expect:
+		def template = service.findTemplate(property, 'wrapper', "biography")
+		template.path == '/_fields/textarea/wrapper'
+		template.plugin == null
+		render(template: template.path) == 'WIDGET TEMPLATE'
+	}
+
+    void "resolves widget template for textarea widget constraint"() {
+		given:
+		views["/_fields/default/_widget.gsp"] = 'DEFAULT FIELD WIDGET'
+		views["/_fields/string/_widget.gsp"] = 'PROPERTY TYPE WIDGET'
+		views["/_fields/textarea/_widget.gsp"] = 'INPUT WIDGET'
+
+		and:
+		def property = factory.accessorFor(personInstance, 'biography')
+
+		expect:
+		def template = service.findTemplate(property, 'widget', "biography")
+		template.path == '/_fields/textarea/widget'
+		template.plugin == null
+		render(template: template.path) == 'INPUT WIDGET'
+	}
+
+    void "resolves display wrapper template for textarea widget constraint"() {
+		given:
+		views["/_fields/default/_displayWrapper.gsp"] = 'DEFAULT DISPLAY TEMPLATE'
+		views["/_fields/string/_displayWrapper.gsp"] = 'PROPERTY TYPE TEMPLATE'
+		views["/_fields/textarea/_displayWrapper.gsp"] = 'OUTPUT TEMPLATE'
+
+		and:
+		def property = factory.accessorFor(personInstance, 'biography')
+
+		expect:
+		def template = service.findTemplate(property, 'displayWrapper', "biography")
+		template.path == '/_fields/textarea/displayWrapper'
+		template.plugin == null
+		render(template: template.path) == 'OUTPUT TEMPLATE'
+	}
+
+    void "resolves display widget template for textarea widget constraint"() {
+		given:
+		views["/_fields/default/_displayWidget.gsp"] = 'DEFAULT FIELD FOR DISPLAY'
+		views["/_fields/string/_displayWidget.gsp"] = 'PROPERTY TYPE FOR DISPLAY'
+		views["/_fields/textarea/_displayWidget.gsp"] = 'OUTPUT FOR DISPLAY'
+
+		and:
+		def property = factory.accessorFor(personInstance, 'biography')
+
+		expect:
+		def template = service.findTemplate(property, 'displayWidget', "biography")
+		template.path == '/_fields/textarea/displayWidget'
+		template.plugin == null
+		render(template: template.path) == 'OUTPUT FOR DISPLAY'
+	}
+
 	void "resolves template for domain class property"() {
 		given:
 		views["/_fields/default/_wrapper.gsp"] = 'DEFAULT FIELD TEMPLATE'

--- a/test/unit/grails/plugin/formfields/mock/Person.groovy
+++ b/test/unit/grails/plugin/formfields/mock/Person.groovy
@@ -18,6 +18,7 @@ class Person {
 	Boolean grailsDeveloper
 	Byte[] picture
 	byte[] anotherPicture
+	String biography
 
     transient String getTransientText() {
         "transient text"
@@ -37,6 +38,7 @@ class Person {
 		picture nullable: true
 		anotherPicture nullable: true
 		password password: true
+		biography nullable: true, widget: 'textarea'
 	}
 
 	static scaffold = [exclude: ['excludedProperty']]


### PR DESCRIPTION
Upon upgrading the Fields plugin from 1.4 to 1.5.1 I noticed that some of my fields were not rendering correctly. The fields in question were those that were associated with domain properties that had widget constraints.

I tracked the issue down to the commit https://github.com/grails-fields-plugin/grails-fields/commit/cac30539d8b73939963162ce43231a11eed955a3 that removed the call to the FormFieldsTemplateService.getWidget() method.


I've reintroduced the call to getWidget() along with relevant tests.