### PR TITLE
Fix #197: Add raw() method to FormFieldsTagLib when using Grails 2.2 or less

### DIFF
--- a/FieldsGrailsPlugin.groovy
+++ b/FieldsGrailsPlugin.groovy
@@ -15,6 +15,7 @@
  */
 
 import grails.plugin.formfields.BeanPropertyAccessorFactory
+import grails.plugin.formfields.LegacyGrailsSupport
 import org.codehaus.groovy.grails.validation.ConstraintsEvaluator
 
 class FieldsGrailsPlugin {
@@ -35,7 +36,7 @@ class FieldsGrailsPlugin {
 	def scm = [system: 'GitHub', url: 'https://github.com/grails-fields-plugin/grails-fields']
     def organization = [ name: "Grails Fields Plugin Developers Group", url: "https://github.com/grails-fields-plugin" ]
 
-	def developers = [ 
+	def developers = [
 		[ name: "Rob Fletcher", email: "rob@freeside.co" ],
 		[ name: "Erik Pragt", email: "erik.pragt@gmail.com" ],
 		[ name: "Dónal Murtagh", email: "domurtag@yahoo.co.uk" ],
@@ -51,5 +52,12 @@ class FieldsGrailsPlugin {
 			proxyHandler = ref('proxyHandler')
 		}
 	}
-	
+
+	def doWithApplicationContext = { ctx ->
+		if (LegacyGrailsSupport.supportedLegacyGrailsVersion) {
+			def formFieldsTagLib = ctx.getBean('grails.plugin.formfields.FormFieldsTagLib')
+			LegacyGrailsSupport.addRawMethodImplementation(formFieldsTagLib)
+		}
+	}
+
 }

--- a/src/groovy/grails/plugin/formfields/LegacyGrailsSupport.groovy
+++ b/src/groovy/grails/plugin/formfields/LegacyGrailsSupport.groovy
@@ -1,0 +1,20 @@
+package grails.plugin.formfields
+
+import grails.util.Metadata
+
+class LegacyGrailsSupport  {
+    static boolean isSupportedLegacyGrailsVersion() {
+        Metadata.current.getGrailsVersion() ==~ /2\.[0-2]\.\d*/
+    }
+
+    static addRawMethodImplementation(Object artefact) {
+        artefact.metaClass.raw = { Object value ->
+            if (value instanceof CharSequence) {
+                new String(value.toString())
+            }
+            else {
+                value
+            }
+        }
+    }
+}

--- a/test/integration/grails/plugin/formfields/LegacyGrailsSupportIntegrationSpec.groovy
+++ b/test/integration/grails/plugin/formfields/LegacyGrailsSupportIntegrationSpec.groovy
@@ -1,0 +1,29 @@
+package grails.plugin.formfields
+
+import grails.util.Holders
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('https://github.com/grails-fields-plugin/grails-fields/issues/197')
+@IgnoreIf({ !LegacyGrailsSupport.supportedLegacyGrailsVersion })
+class LegacyGrailsSupportIntegrationSpec extends Specification {
+
+    def grailsApplication
+
+    void setup() {
+        grailsApplication = Holders.grailsApplication
+    }
+
+    void 'raw() method is added to FormFieldsTagLib'() {
+        given:
+        def tagLib = grailsApplication.mainContext.getBean(FormFieldsTagLib)
+
+        when:
+        tagLib.raw('test value')
+
+        then:
+        notThrown MissingMethodException
+    }
+
+}

--- a/test/unit/grails/plugin/formfields/LegacyGrailsSupportSpec.groovy
+++ b/test/unit/grails/plugin/formfields/LegacyGrailsSupportSpec.groovy
@@ -1,0 +1,125 @@
+package grails.plugin.formfields
+
+import grails.test.mixin.TestMixin
+import grails.test.mixin.support.GrailsUnitTestMixin
+import grails.util.Metadata
+import org.codehaus.groovy.grails.plugins.codecs.HTMLCodec
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@TestMixin(GrailsUnitTestMixin)
+class LegacyGrailsSupportSpec extends Specification {
+    final String actualGrailsVersion = Metadata.current.getGrailsVersion()
+
+    void setup() {
+        mockCodec(HTMLCodec)
+    }
+
+    void cleanup() {
+        grailsVersion = actualGrailsVersion
+    }
+
+    @Unroll('returns #expected when Grails version is #version')
+    void 'returns true if Grails is a supported legacy version'() {
+        given:
+        grailsVersion = version
+
+        expect:
+        LegacyGrailsSupport.supportedLegacyGrailsVersion == expected
+
+        where:
+        version | expected
+        '1.3.9' | false
+        '2.0.0' | true
+        '2.1.0' | true
+        '2.2.0' | true
+        '2.2.5' | true
+        '2.3.0' | false
+        '2.4.0' | false
+        '2.5.0' | false
+        '3.0.0' | false
+        '3.0.3' | false
+    }
+
+    void 'add raw() method to artefact'() {
+        given:
+        def dummyArtefact = new Object()
+
+        when:
+        dummyArtefact.raw('test string')
+
+        then:
+        thrown MissingMethodException
+
+        when:
+        LegacyGrailsSupport.addRawMethodImplementation(dummyArtefact)
+
+        and:
+        dummyArtefact.raw('test string')
+
+        then:
+        notThrown MissingMethodException
+    }
+
+    void 'raw() method returns an equivalent String'() {
+        given:
+        def dummyArtefact = new Object()
+        LegacyGrailsSupport.addRawMethodImplementation(dummyArtefact)
+
+        expect:
+        dummyArtefact.raw('test string') == 'test string'
+    }
+
+    void 'raw() method returns a new copy a String instance'() {
+        given:
+        def dummyArtefact = new Object()
+        LegacyGrailsSupport.addRawMethodImplementation(dummyArtefact)
+
+        and:
+        def value = 'test string'
+
+        when:
+        def result = dummyArtefact.raw(value)
+
+        then:
+        !result.is(value)
+    }
+
+    void 'raw() returns a String when passed an non-String CharSequence'() {
+        given:
+        def dummyArtefact = new Object()
+        LegacyGrailsSupport.addRawMethodImplementation(dummyArtefact)
+
+        and:
+        def value = 'Char' << 'Sequence'
+
+        expect:
+        value instanceof CharSequence && !(value instanceof String)
+
+        when:
+        def result = dummyArtefact.raw(value)
+
+        then:
+        result instanceof String
+        result == 'CharSequence'
+    }
+
+    void 'raw() method returns non-CharSequence instance untouched'() {
+        given:
+        def dummyArtefact = new Object()
+        LegacyGrailsSupport.addRawMethodImplementation(dummyArtefact)
+
+        and:
+        def value = new Date()
+
+        when:
+        def result = dummyArtefact.raw(value)
+
+        then:
+        result.is value
+    }
+
+    private void setGrailsVersion(String version) {
+        Metadata.current.put(Metadata.APPLICATION_GRAILS_VERSION, version)
+    }
+}

--- a/test/unit/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
@@ -1,6 +1,7 @@
 package grails.plugin.formfields.taglib
 
 import grails.plugin.formfields.BeanPropertyAccessorFactory
+import grails.plugin.formfields.LegacyGrailsSupport
 import org.codehaus.groovy.grails.support.proxy.DefaultProxyHandler
 import org.codehaus.groovy.grails.validation.DefaultConstraintEvaluator
 import spock.lang.Specification
@@ -46,6 +47,12 @@ abstract class AbstractFormFieldsTagLibSpec extends Specification {
 	 		}
 	 		null // stops default return
 	 	}
+	}
+
+	protected void addRawMethodIfRequired(tagLib) {
+		if (LegacyGrailsSupport.supportedLegacyGrailsVersion) {
+			LegacyGrailsSupport.addRawMethodImplementation tagLib
+		}
 	}
 
 }

--- a/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -23,6 +23,7 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
         mockFormFieldsTemplateService.getTemplateFor('displayWidget') >> "displayWidget"
 
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
+        addRawMethodIfRequired tagLib
 	}
 
 	void 'renders value using g:fieldValue if no template is present'() {

--- a/test/unit/grails/plugin/formfields/taglib/FieldTagWithBodySpec.groovy
+++ b/test/unit/grails/plugin/formfields/taglib/FieldTagWithBodySpec.groovy
@@ -26,6 +26,7 @@ class FieldTagWithBodySpec extends AbstractFormFieldsTagLibSpec {
         mockFormFieldsTemplateService.getTemplateFor('displayWidget') >> "displayWidget"
         mockFormFieldsTemplateService.getWidgetPrefix() >> 'input-'
 		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
+        addRawMethodIfRequired tagLib
 	}
 
     void 'tag body can be used instead of the input'() {

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -37,7 +37,7 @@ perl -i -p -e "s/app\\.grails\\.version=.*/app.grails.version=$use_grails_versio
 
 set -e
 grails refresh-dependencies --non-interactive
-grails test-app --non-interactive :unit
+grails test-app --non-interactive unit:
 grails test-app --non-interactive -echoOut -echoErr :cli
 grails package-plugin --non-interactive
 grails maven-install --non-interactive

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -38,6 +38,7 @@ perl -i -p -e "s/app\\.grails\\.version=.*/app.grails.version=$use_grails_versio
 set -e
 grails refresh-dependencies --non-interactive
 grails test-app --non-interactive unit:
+grails test-app --non-interactive integration:
 grails test-app --non-interactive -echoOut -echoErr :cli
 grails package-plugin --non-interactive
 grails maven-install --non-interactive


### PR DESCRIPTION
I've attempted to fix issue #197  by adding a `raw()` method to the `FormFieldsTagLib` when using Grails 2.0 - 2.2.

I've created a utility class `LegacyGrailsSupport` which has a method to check the version of Grails and another to add the `raw()` method to an object. The implementation of the `raw()` method is based on [`RawCodec.encode()`](https://github.com/grails/grails-core/blob/13339a2072a796c6ac3bcd78d93b509b8d45475f/grails-encoder/src/main/groovy/org/codehaus/groovy/grails/plugins/codecs/RawCodec.java#L59).

The unit tests have been updated to add the `raw()` method to the `FormFieldsTagLib` when required.

I've added an integration test to ensure the `raw()` method is added by `FieldsGrailsPlugin.doWithApplicationContext()`. Note: I haven't extended `IntegrationSpec` here as the package name has changed since Spock support was added by default in Grails 2.3. I've retrieved the `GrailsApplication` via `grails.util.Holders` as this is available across all 2.x versions of Grails.

