### PR TITLE
Issue #210: Propagation of f:with and f:all attributes to child tags …

### DIFF
--- a/src/docs/guide/usage.gdoc
+++ b/src/docs/guide/usage.gdoc
@@ -71,6 +71,11 @@ By default _f:display_ simply renders the property value but if you supply a _\_
 <dd>${value}</dd>
 {code}
 
+h2. Extra attributes (Since version 2.1.4)
+
+You can pass any number of extra attributes to the _f:with_ and _f:all_ tags that will be propagated to the inner fields and displays.
+See their individual tags sections for more information.
+
 h2. Breaking changes
 
 h3. Templates

--- a/src/docs/ref/Tags/all.gdoc
+++ b/src/docs/ref/Tags/all.gdoc
@@ -15,3 +15,20 @@ h2. Attributes
 *order* | | A comma-separated list of properties which represents the order in which the tag should generate fields.
 *prefix* | String | A string (including the trailing period) that should be appended before the input name such as @name="${prefix}propertyName"@.  The label is also modified.
 {table}
+
+
+h2. Extra attributes (Since version 2.1.4)
+
+You can pass extra attributes to the *all* tag that will be propagated to the inner fields.
+
+h3. Example
+
+{code}
+<f:all bean="person" wrapper="someWrapper"/>
+{code}
+
+In that way all the fields are going to be executed as if they were executed with the extra attribute on them.
+
+{note}
+    Remember that if you want to use some of those attributes in the *widget* templates you need to prefix them with the *widget-* word (unless you have configured another prefix)
+{note}

--- a/src/docs/ref/Tags/with.gdoc
+++ b/src/docs/ref/Tags/with.gdoc
@@ -20,3 +20,41 @@ h3. Attributes
 *bean* | yes | The bean whose property is being rendered. This can be the object itself or the name of a page-scope variable.
 *prefix* | String | A string (including the trailing period) that should be appended before the input name such as @name="${prefix}propertyName"@.  The label is also modified.
 {table}
+
+
+ h2. Extra attributes (Since version 2.1.4)
+
+ You can pass any number of extra attributes to the *with* tag that will be propagated to the inner fields and displays.
+
+ {code}
+ <f:with bean="person" wrapper="someWrapper">
+     <f:field property="name"/>
+     <f:field property="address.city"/>
+ </f:with>
+ {code}
+
+ That way you don't need to repeat the same attribute over and over.
+ The code above is the same as:
+
+ {code}
+ <f:with bean="person">
+     <f:field property="name" wrapper="someWrapper"/>
+     <f:field property="address.city" wrapper="someWrapper"/>
+ </f:with>
+ {code}
+
+ h4. Override extra attributes
+
+ You can override the extra attributes on any field just changing the attribute value on the popper field or display
+
+ {code}
+ <f:with bean="person" wrapper="someWrapper">
+     <f:field property="name"/>
+     <f:field property="address.city"/>
+     <f:field property="address.zip" wrapper="differentWrapper"/>
+ </f:with>
+ {code}
+
+ {note}
+     Remember that if you want to use some of those attributes in the *widget* or *displayWidget* templates you need to prefix them with the *widget-* word (unless you have configured another prefix)
+ {note}

--- a/src/test/groovy/grails/plugin/formfields/taglib/AttributesOfWithAndAllTagsArePropagatedSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/AttributesOfWithAndAllTagsArePropagatedSpec.groovy
@@ -1,0 +1,185 @@
+package grails.plugin.formfields.taglib
+
+import grails.plugin.formfields.FormFieldsTagLib
+import grails.plugin.formfields.FormFieldsTemplateService
+import grails.plugin.formfields.mock.Product
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import spock.lang.Ignore
+import spock.lang.Issue
+import spock.lang.Unroll
+
+@TestFor(FormFieldsTagLib)
+@Mock([Product])
+@Unroll
+@Issue('https://github.com/grails-fields-plugin/grails-fields/issues/210')
+class AttributesOfWithAndAllTagsArePropagatedSpec extends AbstractFormFieldsTagLibSpec {
+
+	def mockFormFieldsTemplateService = Mock(FormFieldsTemplateService)
+
+	def setupSpec() {
+		configurePropertyAccessorSpringBean()
+	}
+
+	def setup() {
+		def taglib = applicationContext.getBean(FormFieldsTagLib)
+
+		mockFormFieldsTemplateService.getWidgetPrefix() >> "widget-"
+		mockFormFieldsTemplateService.getTemplateFor("wrapper") >> 'wrapper'
+		mockFormFieldsTemplateService.getTemplateFor("displayWrapper") >> 'displayWrapper'
+		mockFormFieldsTemplateService.getTemplateFor("widget") >> 'widget'
+		mockFormFieldsTemplateService.getTemplateFor("displayWidget") >> 'displayWidget'
+
+		mockFormFieldsTemplateService.findTemplate(_, 'wrapper', null) >> [path: '/_fields/default/wrapper']
+		mockFormFieldsTemplateService.findTemplate(_, 'displayWrapper', null) >> [path: '/_fields/default/displayWrapper']
+
+		mockFormFieldsTemplateService.findTemplate(_, 'widget', null) >> [path: '/_fields/default/widget']
+		mockFormFieldsTemplateService.findTemplate(_, 'displayWidget', null) >> [path: '/_fields/default/displayWidget']
+
+		taglib.formFieldsTemplateService = mockFormFieldsTemplateService
+
+		mockEmbeddedSitemeshLayout(taglib)
+
+		views["/_fields/default/_wrapper.gsp"] = '<wrapper attr="${attribute}">${widget}</wrapper>'
+		views["/_fields/default/_displayWrapper.gsp"] = '<displayWrapper attr="${attribute}">${widget}</displayWrapper>'
+		views["/_fields/default/_widget.gsp"] = '<widget>${property}</widget>'
+		views["/_fields/default/_displayWidget.gsp"] = '<displayWidget>${property}</displayWidget>'
+	}
+
+	void "An attribute of the <f:with> tag is present on a field tag"() {
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" attribute="cool">' +
+						'<f:field property="name"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<wrapper attr="cool"><widget>name</widget></wrapper>'
+	}
+
+	void "An attribute of the <f:with> tag is present on an inner display tag"() {
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" attribute="cool">' +
+						'<f:display property="name"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<displayWrapper attr="cool"><displayWidget>name</displayWidget></displayWrapper>'
+	}
+
+	void "An attribute of the <f:all> tag is present on inner fields tag"() {
+		expect:
+		applyTemplate(
+				'<f:all bean="productInstance" attribute="cool"/>',
+				[productInstance: productInstance]
+		) == '<wrapper attr="cool"><widget>name</widget></wrapper>' +
+				'<wrapper attr="cool"><widget>netPrice</widget></wrapper>' +
+				'<wrapper attr="cool"><widget>taxRate</widget></wrapper>' +
+				'<wrapper attr="cool"><widget>tax</widget></wrapper>'
+	}
+
+	@Ignore("It is not possible to use the <f:all> tag for printing displays instead of fields")
+	void "An attribute of the <f:displayAll> tag is present on inner displays tag"() {
+		expect:
+		applyTemplate(
+				'<f:displayAll bean="productInstance" wrapper="cool"/>',
+				[productInstance: productInstance]
+		) == '<displayWrapper attr="cool"><displayWidget>name</displayWidget></displayWrapper>' +
+				'<displayWrapper attr="cool"><displayWidget>netPrice</displayWidget></displayWrapper>' +
+				'<displayWrapper attr="cool"><displayWidget>taxRate</displayWidget></displayWrapper>' +
+				'<displayWrapper attr="cool"><displayWidget>tax</displayWidget></displayWrapper>'
+	}
+
+	//Test Override of attributes
+
+	void "<f:field> attributes overrides <f:with> attributes"() {
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" attribute="general-attr">' +
+						'<f:field property="name" attribute="override-attr"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<wrapper attr="override-attr"><widget>name</widget></wrapper>'
+	}
+
+	void "<f:display> attributes overrides <f:with> attributes"() {
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" attribute="general-attr">' +
+						'<f:display property="name" attribute="override-attr"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<displayWrapper attr="override-attr"><displayWidget>name</displayWidget></displayWrapper>'
+	}
+
+	//Test cascade tags
+
+	void "Test cascade of <f:with> tags"() {
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" attribute="general-attr">' +
+						'<f:field property="name"/>' +
+						'<f:field property="netPrice"/>' +
+						'<f:with bean="productInstance" attribute="override-attr">' +
+						'<f:field property="taxRate"/>' +
+						'</f:with>' +
+						'<f:display property="tax"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<wrapper attr="general-attr"><widget>name</widget></wrapper>' +
+				'<wrapper attr="general-attr"><widget>netPrice</widget></wrapper>' +
+				'<wrapper attr="override-attr"><widget>taxRate</widget></wrapper>' +
+				'<displayWrapper attr="general-attr"><displayWidget>tax</displayWidget></displayWrapper>'
+	}
+
+	void "An attribute of the <f:with> tag (prefixed with 'widget-') is present on an inner <f:widget> tag"() {
+		given:
+		views["/_fields/default/_widget.gsp"] = '<widget attr="${attribute}">${property}</widget>'
+
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" widget-attribute="cool">' +
+						'<f:widget property="name"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<widget attr="cool">name</widget>'
+	}
+
+	void "An attribute of the <f:with> tag (prefixed with 'widget-') is present on an inner <f:displayWidget> tag"() {
+		given:
+		views["/_fields/default/_displayWidget.gsp"] = '<displayWidget attr="${attribute}">${property}</displayWidget>'
+
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" widget-attribute="cool">' +
+						'<f:displayWidget property="name"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<displayWidget attr="cool">name</displayWidget>'
+	}
+
+	void "An attribute inside an <f:widget> tag can override an extra attribute of his parent <f:with>"() {
+		given:
+		views["/_fields/default/_widget.gsp"] = '<widget attr="${attribute}">${property}</widget>'
+
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" widget-attribute="cool">' +
+						'<f:widget property="name" attribute="very cool"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<widget attr="very cool">name</widget>'
+	}
+
+	void "An attribute inside an <f:displayWidget> tag can override an extra attribute of his parent <f:with>"() {
+		given:
+		views["/_fields/default/_displayWidget.gsp"] = '<displayWidget attr="${attribute}">${property}</displayWidget>'
+
+		expect:
+		applyTemplate(
+				'<f:with bean="productInstance" widget-attribute="cool">' +
+						'<f:displayWidget property="name" attribute="very cool"/>' +
+						'</f:with>',
+				[productInstance: productInstance]
+		) == '<displayWidget attr="very cool">name</displayWidget>'
+	}
+}


### PR DESCRIPTION
…by mpccolorado

This commit brings several patches by mpccolorado to the grails3 branch.
It resolves issue #210 with the intent of keeping field declarations DRY
by including common attributes in the enclosing f:with and f:all tags.

The commit contains:
- implementation of the feature
- unit tests
- documentation

https://github.com/grails-fields-plugin/grails-fields/issues/210
