### PR TITLE
#219 #212 - update display and table tags to use resolvePersistentPro…

### DIFF
--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -92,8 +92,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
 	/**
 	 * @attr bean REQUIRED Name of the source bean in the GSP model.
-	 * @attr except A comma-separated list of properties to exclude from
-	 * the generated list of input fields.
+	 * @attr order A comma-separated list of properties to include in provided order
+	 * @attr except A comma-separated list of properties to exclude from the generated list of input fields
 	 * @attr prefix Prefix to add to input element names.
 	 */
 	def all = { attrs ->
@@ -188,6 +188,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
       * Defaults to the first 7 (or less) properties of the domain class ordered by the domain class' constraints.
       * @attr displayStyle OPTIONAL Determines the display template used for the bean's properties.
       * Defaults to 'table', meaning that 'display-table' templates will be used when available.
+	  * @attr order A comma-separated list of properties to include in provided order
+	  * @attr except A comma-separated list of properties to exclude
       */
     def table = { attrs, body ->
         def collection = resolveBean(attrs.remove('collection'))
@@ -202,7 +204,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
          if (attrs.containsKey('properties')) {
             properties = attrs.remove('properties').collect { domainClass.getPropertyByName(it) }
          } else {
-            properties = domainClass.persistentProperties.sort(new DomainClassPropertyComparator(domainClass))
+            properties = resolvePersistentProperties(domainClass, attrs)
             if (properties.size() > 6) {
                 properties = properties[0..6]
             }
@@ -266,8 +268,9 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
 	/**
 	 * @attr bean Name of the source bean in the GSP model.
-	 * @attr property REQUIRED The name of the property to display. This is resolved
-	 * against the specified bean or the bean in the current scope.
+	 * @attr property The name of the property to display. This is resolved against the specified bean or the bean in the current scope.
+	 * @attr order A comma-separated list of properties to include in provided order
+	 * @attr except A comma-separated list of properties to exclude
 	 */
 	def display = { attrs, body ->
 		attrs = beanStack.innerAttributes + attrs
@@ -280,7 +283,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		if (property == null) {
 			GrailsDomainClass domainClass = resolveDomainClass(bean)
 			if (domainClass) {
-				def properties = domainClass.persistentProperties.sort(new DomainClassPropertyComparator(domainClass))
+				List properties = resolvePersistentProperties(domainClass, attrs)
 				out << render(template: "/templates/_fields/list", model: [domainClass: domainClass, domainProperties: properties]) { prop ->
 					def propertyAccessor = resolveProperty(bean, prop.name)
 					def model = buildModel(propertyAccessor, attrs)
@@ -436,8 +439,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 		grailsApplication.getDomainClass(beanClass.name)
 	}
 
-    private List<GrailsDomainClassProperty> resolvePersistentProperties(GrailsDomainClass domainClass, attrs) {
-        def properties
+    private List<GrailsDomainClassProperty> resolvePersistentProperties(GrailsDomainClass domainClass, Map attrs) {
+        List<GrailsDomainClassProperty> properties
 
         if(attrs.order) {
             if(attrs.except) {
@@ -449,7 +452,7 @@ class FormFieldsTagLib implements GrailsApplicationAware {
             properties = domainClass.persistentProperties as List
             def blacklist = attrs.except?.tokenize(',')*.trim() ?: []
             blacklist << 'dateCreated' << 'lastUpdated'
-            def scaffoldProp = getStaticPropertyValue(domainClass.clazz, 'scaffold')
+            Map scaffoldProp = getStaticPropertyValue(domainClass.clazz, 'scaffold')
             if (scaffoldProp) {
                 blacklist.addAll(scaffoldProp.exclude)
             }
@@ -459,7 +462,8 @@ class FormFieldsTagLib implements GrailsApplicationAware {
 
             Collections.sort(properties, new org.grails.validation.DomainClassPropertyComparator(domainClass))
         }
-        properties
+
+		return properties
     }
 
 	private boolean hasBody(Closure body) {

--- a/grails-app/views/templates/_fields/_list.gsp
+++ b/grails-app/views/templates/_fields/_list.gsp
@@ -1,5 +1,5 @@
 <ol class="property-list ${domainClass.propertyName}">
-    <g:each in="${domainClass.persistentProperties}" var="p">
+    <g:each in="${domainProperties}" var="p">
         <li class="fieldcontain">
             <span id="${p.name}-label" class="property-label"><g:message code="${domainClass.propertyName}.${p.name}.label" default="${p.naturalName}" /></span>
             <div class="property-value" aria-labelledby="${p.name}-label">${body(p)}</div>

--- a/src/docs/ref/Tags/display.gdoc
+++ b/src/docs/ref/Tags/display.gdoc
@@ -44,6 +44,8 @@ h2. Attributes
 *default* | | A default value for the property that will be used if the actual property value is _falsy_.
 *label* | | Overrides the field label passed to the template. This value may either be an i18n key or a literal string.
 *displayStyle* | | When specified and different from the string _default_, this tag will try to use a _\_display-${displayStyle}_ template with a _\_display_ template as fallback. _displayStyle="table"_ will render embedded components by default with _toString()_ in stead of rendering all nested properties.
+*except* | | A comma-separated list of properties that should be skipped.
+*order* | | A comma-separated list of properties which represents the order in which the tag should display them.
 {table}
 
 Any additional attributes are passed to the rendered template.

--- a/src/docs/ref/Tags/table.gdoc
+++ b/src/docs/ref/Tags/table.gdoc
@@ -24,6 +24,8 @@ h2. Attributes
  *domainClass* | | The FQN of the domain class of the elements in the collection. Defaults to the class of the first element in the collection.
  *properties* | | The list of properties to be shown (table columns). Defaults to the first 7 (or less) properties of the domain class ordered by the domain class' constraints.
  *displayStyle* | | Determines the display template used for the bean's properties. Defaults to _table_, meaning that _\_display-table_ templates will be used when available.
+ *except* | | A comma-separated list of properties that should be skipped.
+ *order* | | A comma-separated list of properties which represents the order in which the tag should display them.
  {table}
 
  Any additional attributes are passed to the rendered template.

--- a/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -41,6 +41,27 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 			result.contains '<div class="property-value" aria-labelledby="gender-label">Male</div>'
 	}
 
+	void 'display tag allows to specify order'() {
+		when:"A list is rendered"
+		def result = applyTemplate('<f:display bean="personInstance" order="salutation,name,gender"/>', [personInstance: personInstance])
+		def ol = new XmlSlurper().parseText(result)
+
+		then:
+		ol.li.span.collect {it.text().trim()} == ["Salutation", "Name", "Gender"]
+		ol.li.div.collect {it.text().trim()} == ["", "Bart Simpson", "Male"]
+	}
+
+	void "display tag allows to specify the except"() {
+		when:
+		def result = applyTemplate('<f:display bean="personInstance" except="salutation,grailsDeveloper,picture,anotherPicture,password"/>', [personInstance: personInstance])
+		def ol = new XmlSlurper().parseText(result)
+
+		then:
+		ol.li.span.collect {it.text().trim()} == ['Name', 'Date Of Birth', 'Address', "Biography", "Emails", "Gender", "Minor"]
+		ol.li.div.collect {it.text().trim()} == ["Bart Simpson", "1987-04-19 00:00:00 IST", "Street94 Evergreen TerraceCitySpringfieldCountryUSA","" , "[:]", "Male", "True"]
+	}
+
+
 
 	void 'renders value using g:fieldValue if no template is present'() {
 		expect:

--- a/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -53,12 +53,12 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 
 	void "display tag allows to specify the except"() {
 		when:
-		def result = applyTemplate('<f:display bean="personInstance" except="salutation,grailsDeveloper,picture,anotherPicture,password"/>', [personInstance: personInstance])
+		def result = applyTemplate('<f:display bean="personInstance" except="salutation,grailsDeveloper,picture,anotherPicture,password,dateOfBirth"/>', [personInstance: personInstance])
 		def ol = new XmlSlurper().parseText(result)
 
 		then:
-		ol.li.span.collect {it.text().trim()} == ['Name', 'Date Of Birth', 'Address', "Biography", "Emails", "Gender", "Minor"]
-		ol.li.div.collect {it.text().trim()} == ["Bart Simpson", "1987-04-19 00:00:00 IST", "Street94 Evergreen TerraceCitySpringfieldCountryUSA","" , "[:]", "Male", "True"]
+		ol.li.span.collect {it.text().trim()} == ['Name', 'Address', "Biography", "Emails", "Gender", "Minor"]
+		ol.li.div.collect {it.text().trim()} == ["Bart Simpson", "Street94 Evergreen TerraceCitySpringfieldCountryUSA","" , "[:]", "Male", "True"]
 	}
 
 

--- a/src/test/groovy/grails/plugin/formfields/taglib/TableSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/TableSpec.groovy
@@ -39,7 +39,7 @@ class TableSpec extends AbstractFormFieldsTagLibSpec {
         def table = new XmlSlurper().parseText(output)
 
         then:
-        table.thead.tr.th.a.collect {it.text().trim()} == ['Salutation', 'Name', 'Date Of Birth', 'Address', 'Excluded Property', 'Display False Property', 'Grails Developer']
+        table.thead.tr.th.a.collect {it.text().trim()} == ['Salutation', 'Name', 'Date Of Birth', 'Address', 'Grails Developer', "Picture", "Another Picture"]
         table.tbody.tr.collect { it.td[1].text() } == ['Bart Simpson', 'Marge Simpson']
     }
 
@@ -53,7 +53,7 @@ class TableSpec extends AbstractFormFieldsTagLibSpec {
         def table = new XmlSlurper().parseText(output)
 
         then:
-        table.thead.tr.th.a.collect {it.text().trim()} == ['Salutation', 'Name', 'Date Of Birth', 'Address', 'Excluded Property', 'Display False Property', 'Grails Developer']
+        table.thead.tr.th.a.collect {it.text().trim()} == ['Salutation', 'Name', 'Date Of Birth', 'Address', 'Grails Developer', "Picture", "Another Picture"]
         table.tbody.tr.collect { it.td[1].text() } == ['Homer Simpson', 'Bart Simpson', 'Marge Simpson']
     }
 
@@ -66,6 +66,27 @@ class TableSpec extends AbstractFormFieldsTagLibSpec {
         then:
         table.thead.tr.th.a.collect {it.text().trim()} == ['Gender', 'Name']
         table.tbody.tr.collect { it.td[0].text() } == ['Male', 'Female']
+    }
+
+    void "table tag allows to specify the order"() {
+        when:
+        def output = applyTemplate('<f:table collection="collection" order="name,gender"/>', [collection: personList])
+        def table = new XmlSlurper().parseText(output)
+
+        then:
+        table.thead.tr.th.a.collect {it.text().trim()} == ['Name', 'Gender']
+        table.tbody.tr.collect { it.td[0].text() } == ['Bart Simpson', 'Marge Simpson']
+        table.tbody.tr.collect { it.td[1].text() } == ['Male', 'Female']
+    }
+
+    void "table tag allows to specify the except"() {
+        when:
+        def output = applyTemplate('<f:table collection="collection" except="salutation,grailsDeveloper,picture,anotherPicture,password"/>', [collection: personList])
+        def table = new XmlSlurper().parseText(output)
+
+        then:
+        table.thead.tr.th.a.collect {it.text().trim()} == ['Name', 'Date Of Birth', 'Address', "Biography", "Emails", "Gender", "Minor"]
+        table.tbody.tr.collect { it.td[0].text() } == ['Bart Simpson', 'Marge Simpson']
     }
 
     void "table tag displays embedded properties by default with toString"() {


### PR DESCRIPTION
connect #219 #212

Fixes #219 
Also fixes #212 -- but support for specifying include is not implemented, i think that needs a bit more designing.

#118 is also related

table: and display tag will now have same behavior as f:all tag for looking up domain properties when property name is not explicitely specified.