### PR TITLE
Remove extra comma from doc fixing table to break

### DIFF
--- a/src/main/docs/ref/Tags/table.adoc
+++ b/src/main/docs/ref/Tags/table.adoc
@@ -37,7 +37,7 @@ When *theme* is specified, the _\_display_ template will be searched first in *t
 *collection*,yes,The collection of beans to be displayed
 *domainClass*,,The FQN of the domain class of the elements in the collection. Defaults to the class of the first element in the collection.
 *properties*,,The list of properties to be shown (table columns). Defaults to the first 7 (or less) properties of the domain class ordered by the domain class' constraints.
-*displayStyle*,,Determines the display template used for the bean's properties. Defaults to _table_, meaning that _\_display-table_ templates will be used when available.
+*displayStyle*,,Determines the display template used for the bean's properties. Defaults to _table_ meaning that _\_display-table_ templates will be used when available.
 *except*,,A comma-separated list of properties that should be skipped.
 *order*,,A comma-separated list of properties which represents the order in which the tag should display them.
 *theme*,String,Theme to use if available.


### PR DESCRIPTION
Even though the comma on line 40 was escaped, the asciidoc renderer being used on github doesn't seem to respect the escape. There are visible escape characters in other parts of the doc too, but I gave up trying to fix. The table was completely broken though, and rather than reformatting the entire table in PSV or the like, I just removed the comma.