### PR TITLE
fix confusing cut-and-paste error from another page

### DIFF
--- a/src/main/docs/ref/Tags/widget.adoc
+++ b/src/main/docs/ref/Tags/widget.adoc
@@ -9,5 +9,5 @@ NOTE: Using `f:widget` directly will only be necessary for very specialized case
 
 ===== Attributes
 
-`f:input` accepts exactly the same attributes as the link:field.html[f:field] tag (except for `wrapper` and `templates` attributes).
+`f:widget` accepts exactly the same attributes as the link:field.html[f:field] tag (except for `wrapper` and `templates` attributes).
 


### PR DESCRIPTION
fix confusing cut-and-paste error from another page