### PR TITLE
Render value that is an association but not to a grom entity

### DIFF
--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -811,9 +811,11 @@ class FormFieldsTagLib implements GrailsApplicationAware {
     }
 
     private CharSequence displayAssociation(value, PersistentEntity referencedDomainClass) {
-        if(value) {
+        if(value && referencedDomainClass) {
             g.link(controller: referencedDomainClass.decapitalizedName, action: "show", id: value.id, value.toString().encodeAsHTML())
-        }
+        } else if(value) {
+			value.toString()
+		}
     }
 
     private boolean isEditable(Constrained constraints) {

--- a/src/test/groovy/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
@@ -22,7 +22,7 @@ abstract class AbstractFormFieldsTagLibSpec extends Specification {
 	def setup() {
 		personInstance = new Person(name: "Bart Simpson", password: "bartman", gender: Gender.Male, dateOfBirth: new Date(87, 3, 19), minor: true)
 		personInstance.address = new Address(street: "94 Evergreen Terrace", city: "Springfield", country: "USA")
-
+		personInstance.emails = [home: "bart@thesimpsons.net", school: "bart.simpson@springfieldelementary.edu"]
         productInstance = new Product(netPrice: 12.33)
 	}
 

--- a/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -53,12 +53,12 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 
 	void "display tag allows to specify the except"() {
 		when:
-		def result = applyTemplate('<f:display bean="personInstance" except="salutation,grailsDeveloper,picture,anotherPicture,password,dateOfBirth"/>', [personInstance: personInstance])
+		def result = applyTemplate('<f:display bean="personInstance" except="salutation,grailsDeveloper,picture,anotherPicture,password,dateOfBirth,emails"/>', [personInstance: personInstance])
 		def ol = new XmlSlurper().parseText(result)
 
 		then:
-		ol.li.span.collect {it.text().trim()}.sort() == ["Address", "Biography", "Emails", "Gender", "Minor", "Name"]
-		ol.li.div.collect {it.text().trim()}.sort() == ["", "", "Bart Simpson", "CitySpringfieldCountryUSAStreet94 Evergreen Terrace", "Male", "True"]
+		ol.li.span.collect {it.text().trim()}.sort() == ["Address", "Biography", "Gender", "Minor", "Name"]
+		ol.li.div.collect {it.text().trim()}.sort() == ["", "Bart Simpson", "CitySpringfieldCountryUSAStreet94 Evergreen Terrace", "Male", "True"]
 	}
 
 
@@ -66,6 +66,11 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec {
 	void 'renders value using g:fieldValue if no template is present'() {
 		expect:
 		applyTemplate('<f:display bean="personInstance" property="name"/>', [personInstance: personInstance]) == personInstance.name
+	}
+
+	void 'renders value that is an association but not to a grom entity'() {
+		expect:
+		applyTemplate('<f:display bean="personInstance" property="emails"/>', [personInstance: personInstance]) == personInstance.emails.toString()
 	}
 
 	void 'renders boolean values using g:formatBoolean'() {


### PR DESCRIPTION
When using on GORM entity: `static hasMany = [emails: String]`

The tag `<f:display bean="personInstance" property="emails"/>` would fail because `referencedDomainClass` is `null`