### PR TITLE
Add support for table templates

### DIFF
--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -216,6 +216,7 @@ class FormFieldsTagLib {
 	 * @attr order A comma-separated list of properties to include in provided order
 	 * @attr except A comma-separated list of properties to exclude
 	 * @attr theme Theme name
+	 * @attr template OPTIONAL The template used when rendering the collection
 	 */
 	def table = { attrs, body ->
 		def collection = resolveBean(attrs.remove('collection'))
@@ -235,9 +236,10 @@ class FormFieldsTagLib {
 
 			String displayStyle = attrs.remove(DISPLAY_STYLE)
 			String theme = attrs.remove(THEME_ATTR)
+			String template = attrs.remove('template') ?: 'table'
 
 			out << render(
-				template: "/templates/_fields/table",
+				template: "/templates/_fields/$template",
 				model: [domainClass: domainClass,
 						domainProperties: columnProperties,
 						columnProperties: columnProperties,

--- a/src/main/docs/ref/Tags/table.adoc
+++ b/src/main/docs/ref/Tags/table.adoc
@@ -49,6 +49,7 @@ When *theme* is specified, the _\_display_ template will be searched first in *t
 |*order*|||Comma-separated `String` or `List` of properties which represents the order in which the tag should display them.
 |*theme*|String||Theme to use if available.
 |*maxProperties*|Number|7|The maximum number of properties to display when rendering the table. If zero is specified all columns are shown, otherwise `properties[0..<maxProperties]` are shown. `maxProperties` can be negative.
+|*template*|String|'table'|Alternative template for table rendering. Templates should be in the 'grails-app/views/templates/_fields/' folder.
 |===
 
  Any additional attributes are passed to the rendered template.


### PR DESCRIPTION
Allows to have multiple templates for table rendering. 
The templates will have to be in the /views/templates/_fields/ folder, but you can specify which template to render with template attribute inside the table tag. 

For example:
<f:table collection="${collection}" template="table2"/>