### PR TITLE
fix warning "Accessing config through dot notation is deprecated" (issue #309)

### DIFF
--- a/src/main/groovy/grails/plugin/formfields/FormFieldsTemplateService.groovy
+++ b/src/main/groovy/grails/plugin/formfields/FormFieldsTemplateService.groovy
@@ -231,7 +231,7 @@ class FormFieldsTemplateService {
 
     private boolean shouldCache() {
         // If not explicitly specified, there is no template caching
-        Boolean cacheDisabled = grailsApplication?.config?.grails?.plugin?.fields?.disableLookupCache
+        Boolean cacheDisabled = grailsApplication?.config?.getProperty('grails.plugin.fields.disableLookupCache', Boolean)
         return !cacheDisabled
     }
 


### PR DESCRIPTION
As the access of the Grails configuration through dot notation is deprecated in version 5 of the framework, I refactored the only place in the fields plugin that is still using dot access.

see https://github.com/grails-fields-plugin/grails-fields/issues/309